### PR TITLE
[PPABV-110] fix: make date too recent test dynamic

### DIFF
--- a/src/test/kotlin/it/pagopa/qi/fdrkpi/service/FdrKpiServiceTest.kt
+++ b/src/test/kotlin/it/pagopa/qi/fdrkpi/service/FdrKpiServiceTest.kt
@@ -6,7 +6,6 @@ import com.microsoft.azure.kusto.data.KustoResultSetTable
 import it.pagopa.generated.qi.fdrkpi.v1.model.KPIEntityResponseAllOfDto.EntityTypeEnum
 import it.pagopa.generated.qi.fdrkpi.v1.model.KPIEntityResponseAllOfDto.KpiNameEnum
 import it.pagopa.generated.qi.fdrkpi.v1.model.KPIResponseDto
-import it.pagopa.qi.fdrkpi.dataprovider.kusto.v1.KustoQueries
 import it.pagopa.qi.fdrkpi.dataprovider.kusto.v1.KustoQueries.LFDR_QUERY
 import it.pagopa.qi.fdrkpi.dataprovider.kusto.v1.KustoQueries.TOTAL_FLOWS_QUERY
 import it.pagopa.qi.fdrkpi.exceptionhandler.*
@@ -29,7 +28,6 @@ class FdrKpiServiceTest {
     private val reKustoClient: Client = mock(Client::class.java)
     private val fdrKpiService: FdrKpiService = FdrKpiService(reKustoClient, "re")
 
-    private val brokerFiscalCode = "02654890025"
     private val pspID = "SARDIT31"
 
     companion object {
@@ -56,61 +54,7 @@ class FdrKpiServiceTest {
                     0,
                     listOf(2, 3),
                     monthlyLfdrBuilder("2", "3", EntityTypeEnum.PSP)
-                ),
-                // WAFDR - daily
-                /* Arguments.of(
-                    WAFDR_QUERY,
-                    KpiNameEnum.WAFDR,
-                    FdrKpiPeriod.daily,
-                    8,
-                    listOf(5),
-                    dailyWafdrBuilder(date, 8, 5, EntityTypeEnum.PSP)
-                ),
-                // WAFDR - monthly
-                Arguments.of(
-                    WAFDR_QUERY,
-                    KpiNameEnum.WAFDR,
-                    FdrKpiPeriod.monthly,
-                    0,
-                    listOf(7),
-                    monthlyWafdrBuilder("7", EntityTypeEnum.PSP)
-                ),
-                // NRFDR - daily
-                Arguments.of(
-                    NRFDR_QUERY,
-                    KpiNameEnum.NRFDR,
-                    FdrKpiPeriod.daily,
-                    6,
-                    listOf(4),
-                    dailyNrfdrBuilder(date, 6, 4, 2, EntityTypeEnum.PSP)
-                ),
-                // NRFDR - monthly
-                Arguments.of(
-                    NRFDR_QUERY,
-                    KpiNameEnum.NRFDR,
-                    FdrKpiPeriod.monthly,
-                    0,
-                    listOf(10),
-                    monthlyNrfdrBuilder("10", EntityTypeEnum.PSP)
-                ),
-                // WPNFDR - daily
-                Arguments.of(
-                    WPNFDR_QUERY,
-                    KpiNameEnum.WPNFDR,
-                    FdrKpiPeriod.daily,
-                    5,
-                    listOf(3),
-                    dailyWpnfdrBuilder(date, 5, 3, EntityTypeEnum.PSP)
-                ),
-                // WPNFDR - monthly
-                Arguments.of(
-                    WPNFDR_QUERY,
-                    KpiNameEnum.WPNFDR,
-                    FdrKpiPeriod.monthly,
-                    0,
-                    listOf(4),
-                    monthlyWpnfdrBuilder("4", EntityTypeEnum.PSP)
-                ),*/
+                )
             )
     }
 
@@ -128,73 +72,15 @@ class FdrKpiServiceTest {
         val dateRange = getDateRange(fdrKpiPeriod, dateString)
 
         if (fdrKpiPeriod == FdrKpiPeriod.daily) {
-            mockKustoResponse(TOTAL_FLOWS_QUERY, dateRange, null, pspID, listOf(totalReports))
+            mockKustoResponse(TOTAL_FLOWS_QUERY, dateRange, pspID, listOf(totalReports))
         }
 
-        mockKustoResponse(queryString, dateRange, null, pspID, queryResponse)
+        mockKustoResponse(queryString, dateRange, pspID, queryResponse)
 
         val response =
             fdrKpiService.calculateKpi(kpiNameEnum.name, fdrKpiPeriod.name, dateString, null, pspID)
         assertEquals(expectedResponse, response)
     }
-
-    /*@ParameterizedTest
-    @MethodSource("successfullyQueriesProvider")
-    fun `Should return correct response from Kusto DB for Broker queries`(
-        queryString: String,
-        kpiNameEnum: KpiNameEnum,
-        fdrKpiPeriod: FdrKpiPeriod,
-        totalReports: Int,
-        queryResponse: List<Any>,
-        expectedResponse: KPIResponseDto
-    ) {
-        val dateString = if (fdrKpiPeriod == FdrKpiPeriod.daily) "2023-10-01" else "2023-10"
-        val dateRange = getDateRange(fdrKpiPeriod, dateString)
-
-        if (fdrKpiPeriod == FdrKpiPeriod.daily) {
-            mockKustoResponse(TOTAL_FLOWS_QUERY, dateRange, brokerFiscalCode, null, listOf(totalReports))
-        }
-
-        mockKustoResponse(queryString, dateRange, brokerFiscalCode, null, queryResponse)
-
-        val response = fdrKpiService.calculateKpi(
-            kpiNameEnum.name,
-            fdrKpiPeriod.name,
-            dateString,
-            brokerFiscalCode,
-            null
-        )
-        assertEquals(expectedResponse, response)
-    }*/
-
-    /*@ParameterizedTest
-    @MethodSource("successfullyQueriesProvider")
-    fun `Should return correct response from Kusto DB for Broker and PSP queries`(
-        queryString: String,
-        kpiNameEnum: KpiNameEnum,
-        fdrKpiPeriod: FdrKpiPeriod,
-        totalReports: Int,
-        queryResponse: List<Any>,
-        expectedResponse: KPIResponseDto
-    ) {
-        val dateString = if (fdrKpiPeriod == FdrKpiPeriod.daily) "2023-10-01" else "2023-10"
-        val dateRange = getDateRange(fdrKpiPeriod, dateString)
-
-        if (fdrKpiPeriod == FdrKpiPeriod.daily) {
-            mockKustoResponse(TOTAL_FLOWS_QUERY, dateRange, null, pspID, listOf(totalReports))
-        }
-
-        mockKustoResponse(queryString, dateRange, null, pspID, queryResponse)
-
-        val response = fdrKpiService.calculateKpi(
-            kpiNameEnum.name,
-            fdrKpiPeriod.name,
-            dateString,
-            null,
-            pspID
-        )
-        assertEquals(expectedResponse, response)
-    }*/
 
     @Test
     fun `Should throw InvalidPeriodException`() {
@@ -244,13 +130,13 @@ class FdrKpiServiceTest {
 
     @Test
     fun `Should throw DateTooRecentException for monthly period`() {
-        val dateString = "2024-12-23"
+        val today = LocalDate.now().toString()
         val ex =
             assertThrows<DateTooRecentException> {
                 fdrKpiService.calculateKpi(
                     KpiNameEnum.LFDR.name,
                     FdrKpiPeriod.daily.name,
-                    dateString,
+                    today,
                     null,
                     pspID
                 )
@@ -258,34 +144,14 @@ class FdrKpiServiceTest {
         assertEquals("Date Too Recent", ex.message)
     }
 
-    /*@Test
-    fun `Should throw NoResultsFoundException when no rows returned`() {
-        val dateString = "2023-10-01"
-        val dateRange = getDateRange(FdrKpiPeriod.daily, dateString)
-
-        mockKustoResponse(TOTAL_FLOWS_QUERY, dateRange, null, pspID, listOf(10))
-        mockKustoEmptyResponse(LFDR_QUERY, dateRange, null, pspID)
-
-        val ex = assertThrows<NoResultsFoundException> {
-            fdrKpiService.calculateKpi(
-                KpiNameEnum.LFDR.name,
-                FdrKpiPeriod.daily.name,
-                dateString,
-                null,
-                pspID
-            )
-        }
-        assertEquals("No Results Found", ex.message)
-    }*/
-
     @Test
     fun `Should throw PspNotFoundException when percV1 and percV2 are -1`() {
         val dateString = "2023-10"
         val dateRange = getDateRange(FdrKpiPeriod.monthly, dateString)
 
-        mockKustoResponse(KustoQueries.TOTAL_FLOWS_QUERY, dateRange, null, "ABCDEFGH", listOf(10))
+        mockKustoResponse(TOTAL_FLOWS_QUERY, dateRange, "ABCDEFGH", listOf(10))
 
-        mockKustoResponse(KustoQueries.LFDR_QUERY, dateRange, null, "ABCDEFGH", listOf(-1, -1))
+        mockKustoResponse(LFDR_QUERY, dateRange, "ABCDEFGH", listOf(-1, -1))
 
         val ex =
             assertThrows<PspNotFoundException> {
@@ -300,34 +166,12 @@ class FdrKpiServiceTest {
         assertEquals("PSP Not Found", ex.message)
     }
 
-    /*@Test
-    fun `Should throw NoResultsFoundException when percV1=0 and percV2=0`() {
-        val dateString = "2023-10-01"
-        val dateRange = getDateRange(FdrKpiPeriod.daily, dateString)
-
-        // TOT_FLOWS => 10
-        mockKustoResponse(TOTAL_FLOWS_QUERY, dateRange, null, pspID, listOf(10))
-        // KPI => 0,0
-        mockKustoResponse(LFDR_QUERY, dateRange, null, pspID, listOf(0, 0))
-
-        val ex = assertThrows<NoResultsFoundException> {
-            fdrKpiService.calculateKpi(
-                KpiNameEnum.LFDR.name,
-                FdrKpiPeriod.daily.name,
-                dateString,
-                null,
-                pspID
-            )
-        }
-        assertEquals("No Results Found", ex.message)
-    }*/
-
     @Test
     fun `Should throw generic Exception when underlying query fails`() {
         val dateString = "2023-10-01"
         val dateRange = getDateRange(FdrKpiPeriod.daily, dateString)
 
-        mockKustoResponse(TOTAL_FLOWS_QUERY, dateRange, null, pspID, listOf(10))
+        mockKustoResponse(TOTAL_FLOWS_QUERY, dateRange, pspID, listOf(10))
 
         val query = prepareQuery(LFDR_QUERY, dateRange.first, dateRange.second, null, pspID)
 
@@ -360,7 +204,6 @@ class FdrKpiServiceTest {
     private fun mockKustoResponse(
         queryString: String,
         dateRange: Pair<LocalDate, LocalDate>,
-        brokerFiscalCode: String?,
         pspId: String?,
         responseRow: List<Any>
     ) {
@@ -374,20 +217,4 @@ class FdrKpiServiceTest {
         given(operationResult.primaryResults).willReturn(resultSet)
         given(reKustoClient.executeQuery("re", preparedQuery)).willReturn(operationResult)
     }
-
-    /*private fun mockKustoEmptyResponse(
-        queryString: String,
-        dateRange: Pair<LocalDate, LocalDate>,
-        brokerFiscalCode: String?,
-        pspId: String?
-    ) {
-        val preparedQuery =
-            prepareQuery(queryString, dateRange.first, dateRange.second, null, pspId)
-        val operationResult = mock(KustoOperationResult::class.java)
-        val resultSet = mock(KustoResultSetTable::class.java)
-
-        given(resultSet.next()).willReturn(false)
-        given(operationResult.primaryResults).willReturn(resultSet)
-        given(reKustoClient.executeQuery("re", preparedQuery)).willReturn(operationResult)
-    }*/
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- Made date too recent unit test dynamic instead of using a static date
- Removed commented out code and unused variables from service test class

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The change was required to build successfully since using a static date for the "date too recent" test would break the build once that date is more than 10 days in the past (it would not be "too recent" anymore)

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Project was built successfully

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
