### PR TITLE
[MAIN-10] fix(brokerId rename): revert brokerId param name

### DIFF
--- a/api-spec/v1/openapi.yaml
+++ b/api-spec/v1/openapi.yaml
@@ -4,8 +4,8 @@ info:
   title: pagoPA FdR KPI
   description: |
     API for retrieving FdR (Flusso di Rendicontazione) KPI metrics for both PSPs and PSP Brokers.
-    For direct PSP queries, use the PSP's fiscal code in the path.
-    For broker queries, use the broker's fiscal code in the path and specify the PSP code as a query parameter.
+    For direct PSP queries, use the PSP's fiscal code as a query parameter.
+    For broker queries, use the broker's fiscal code and optionally specify the PSP code as query parameters.
 servers:
   - url: https://${host}
 
@@ -20,16 +20,15 @@ paths:
         - qiFdr
       operationId: calculateKpi
       parameters:
-        - name: brokerId
+        - name: brokerFiscalCode
           in: query
           required: false
           schema:
             type: string
             example: "02654890025"
           description: |
-            The fiscal code of the entity:
-            - For direct PSP queries: use PSP fiscal code
-            - For broker queries: use broker fiscal code
+            The fiscal code of the broker.
+            At least one between brokerFiscalCode and pspId must be provided
 
         - name: pspId
           in: query
@@ -38,9 +37,8 @@ paths:
             type: string
             example: "CIPBITMM"
           description: |
-            PSP code - Required only for broker queries.
-            - If entityCode is a broker fiscal code: this parameter is required
-            - If entityCode is a PSP fiscal code: this parameter should not be provided (it would be a duplicate)
+            The fiscal code of the PSP.
+            At least one between brokerFiscalCode and pspId must be provided
 
         - name: kpiType
           in: path
@@ -116,7 +114,7 @@ components:
       properties:
         pspId:
           type: string
-        brokerId:
+        brokerFiscalCode:
           type: string
         kpiDescription:
           type: string
@@ -157,9 +155,9 @@ components:
     BrokerIdentifier:
       type: object
       required:
-        - brokerId
+        - brokerFiscalCode
       properties:
-        brokerId:
+        brokerFiscalCode:
           type: string
           example: "02654890025"
 

--- a/api-tests/env/fdrkpi_dev.env.json
+++ b/api-tests/env/fdrkpi_dev.env.json
@@ -21,13 +21,13 @@
       "enabled": true
     },
     {
-      "key": "BROKER_ID",
+      "key": "BROKER_FISCAL_CODE",
       "value": "99999000001",
       "type": "default",
       "enabled": true
     },
     {
-      "key": "BROKER_ID_NOT_FOUND",
+      "key": "BROKER_FISCAL_CODE_NOT_FOUND",
       "value": "01011001101",
       "type": "default",
       "enabled": true

--- a/api-tests/env/fdrkpi_local.env.json
+++ b/api-tests/env/fdrkpi_local.env.json
@@ -21,13 +21,13 @@
       "enabled": true
     },
     {
-      "key": "BROKER_ID",
+      "key": "BROKER_FISCAL_CODE",
       "value": "01153230360",
       "type": "default",
       "enabled": true
     },
     {
-      "key": "BROKER_ID_NOT_FOUND",
+      "key": "BROKER_FISCAL_CODE_NOT_FOUND",
       "value": "01011001101",
       "type": "default",
       "enabled": true

--- a/api-tests/env/fdrkpi_uat.env.json
+++ b/api-tests/env/fdrkpi_uat.env.json
@@ -21,13 +21,13 @@
       "enabled": true
     },
     {
-      "key": "BROKER_ID",
+      "key": "BROKER_FISCAL_CODE",
       "value": "01153230360",
       "type": "default",
       "enabled": true
     },
     {
-      "key": "BROKER_ID_NOT_FOUND",
+      "key": "BROKER_FISCAL_CODE_NOT_FOUND",
       "value": "01011001101",
       "type": "default",
       "enabled": true

--- a/api-tests/v1/qi-fdrkpi.api.tests.dev.json
+++ b/api-tests/v1/qi-fdrkpi.api.tests.dev.json
@@ -83,7 +83,7 @@
               "    const kpiType = pm.request.url.path[1];",
               "    const expectedResponseType = `${period === 'monthly' ? 'Monthly' : 'Daily'}${kpiType}Metrics`;",
               "    pm.expect(response).to.have.property('responseType').to.equal(expectedResponseType);",
-              "    pm.expect(response).to.have.property('brokerId');",
+              "    pm.expect(response).to.have.property('brokerFiscalCode');",
               "    pm.expect(response).to.have.property('kpiName');",
               "    pm.expect(response).to.have.property('kpiDescription');",
               "    pm.expect(response).to.have.property('kpiDescriptionUrl');",
@@ -108,7 +108,7 @@
           }
         ],
         "url": {
-          "raw": "{{HOSTNAME}}/qi/fdr-kpi-service/v1/fdr-kpi/{{KPI_TYPE_WPNFDR}}?brokerId={{BROKER_ID}}&period={{PERIOD_MONTH}}&date={{DATE_MONTH}}",
+          "raw": "{{HOSTNAME}}/qi/fdr-kpi-service/v1/fdr-kpi/{{KPI_TYPE_WPNFDR}}?brokerFiscalCode={{BROKER_FISCAL_CODE}}&period={{PERIOD_MONTH}}&date={{DATE_MONTH}}",
           "host": ["{{HOSTNAME}}"],
           "path": [
             "qi",
@@ -119,8 +119,8 @@
           ],
           "query": [
             {
-              "key": "brokerId",
-              "value": "{{BROKER_ID}}"
+              "key": "brokerFiscalCode",
+              "value": "{{BROKER_FISCAL_CODE}}"
             },
             {
               "key": "period",
@@ -148,7 +148,7 @@
               "    const kpiType = pm.request.url.path[1];",
               "    const expectedResponseType = `${period === 'monthly' ? 'Monthly' : 'Daily'}${kpiType}Metrics`;",
               "    pm.expect(response).to.have.property('responseType').to.equal(expectedResponseType);",
-              "    pm.expect(response).to.have.property('brokerId');",
+              "    pm.expect(response).to.have.property('brokerFiscalCode');",
               "    pm.expect(response).to.have.property('kpiName');",
               "    pm.expect(response).to.have.property('kpiDescription');",
               "    pm.expect(response).to.have.property('kpiDescriptionUrl');",
@@ -173,7 +173,7 @@
           }
         ],
         "url": {
-          "raw": "{{HOSTNAME}}/qi/fdr-kpi-service/v1/fdr-kpi/{{KPI_TYPE_NRFDR}}?brokerId={{BROKER_ID}}&period={{PERIOD_DAY}}&date={{DATE_DAY}}",
+          "raw": "{{HOSTNAME}}/qi/fdr-kpi-service/v1/fdr-kpi/{{KPI_TYPE_NRFDR}}?brokerFiscalCode={{BROKER_FISCAL_CODE}}&period={{PERIOD_DAY}}&date={{DATE_DAY}}",
           "host": ["{{HOSTNAME}}"],
           "path": [
             "qi",
@@ -184,8 +184,8 @@
           ],
           "query": [
             {
-              "key": "brokerId",
-              "value": "{{BROKER_ID}}"
+              "key": "brokerFiscalCode",
+              "value": "{{BROKER_FISCAL_CODE}}"
             },
             {
               "key": "period",
@@ -213,7 +213,7 @@
               "    const kpiType = pm.request.url.path[1];",
               "    const expectedResponseType = `${period === 'monthly' ? 'Monthly' : 'Daily'}${kpiType}Metrics`;",
               "    pm.expect(response).to.have.property('responseType').to.equal(expectedResponseType);",
-              "    pm.expect(response).to.have.property('brokerId');",
+              "    pm.expect(response).to.have.property('brokerFiscalCode');",
               "    pm.expect(response).to.have.property('pspId');",
               "    pm.expect(response).to.have.property('kpiName');",
               "    pm.expect(response).to.have.property('kpiDescription');",
@@ -239,7 +239,7 @@
           }
         ],
         "url": {
-          "raw": "{{HOSTNAME}}/qi/fdr-kpi-service/v1/fdr-kpi/{{KPI_TYPE_WAFDR}}?brokerId={{BROKER_ID}}&pspId={{PSP_ID}}&period={{PERIOD_DAY}}&date={{DATE_DAY}}",
+          "raw": "{{HOSTNAME}}/qi/fdr-kpi-service/v1/fdr-kpi/{{KPI_TYPE_WAFDR}}?brokerFiscalCode={{BROKER_FISCAL_CODE}}&pspId={{PSP_ID}}&period={{PERIOD_DAY}}&date={{DATE_DAY}}",
           "host": ["{{HOSTNAME}}"],
           "path": [
             "qi",
@@ -250,8 +250,8 @@
           ],
           "query": [
             {
-              "key": "brokerId",
-              "value": "{{BROKER_ID}}"
+              "key": "brokerFiscalCode",
+              "value": "{{BROKER_FISCAL_CODE}}"
             },
             {
               "key": "pspId",

--- a/api-tests/v1/qi-fdrkpi.api.tests.local.json
+++ b/api-tests/v1/qi-fdrkpi.api.tests.local.json
@@ -80,7 +80,7 @@
               "    const kpiType = pm.request.url.path[1];",
               "    const expectedResponseType = `${period === 'monthly' ? 'Monthly' : 'Daily'}${kpiType}Metrics`;",
               "    pm.expect(response).to.have.property('responseType').to.equal(expectedResponseType);",
-              "    pm.expect(response).to.have.property('brokerId');",
+              "    pm.expect(response).to.have.property('brokerFiscalCode');",
               "    pm.expect(response).to.have.property('kpiName');",
               "    pm.expect(response).to.have.property('kpiDescription');",
               "    pm.expect(response).to.have.property('kpiDescriptionUrl');",
@@ -105,7 +105,7 @@
           }
         ],
         "url": {
-          "raw": "{{HOSTNAME}}/fdr-kpi/{{KPI_TYPE_WPNFDR}}?brokerId={{BROKER_ID}}&period={{PERIOD_MONTH}}&date={{DATE_MONTH}}",
+          "raw": "{{HOSTNAME}}/fdr-kpi/{{KPI_TYPE_WPNFDR}}?brokerFiscalCode={{BROKER_FISCAL_CODE}}&period={{PERIOD_MONTH}}&date={{DATE_MONTH}}",
           "host": ["{{HOSTNAME}}"],
           "path": [
             "fdr-kpi",
@@ -113,8 +113,8 @@
           ],
           "query": [
             {
-              "key": "brokerId",
-              "value": "{{BROKER_ID}}"
+              "key": "brokerFiscalCode",
+              "value": "{{BROKER_FISCAL_CODE}}"
             },
             {
               "key": "period",
@@ -142,7 +142,7 @@
               "    const kpiType = pm.request.url.path[1];",
               "    const expectedResponseType = `${period === 'monthly' ? 'Monthly' : 'Daily'}${kpiType}Metrics`;",
               "    pm.expect(response).to.have.property('responseType').to.equal(expectedResponseType);",
-              "    pm.expect(response).to.have.property('brokerId');",
+              "    pm.expect(response).to.have.property('brokerFiscalCode');",
               "    pm.expect(response).to.have.property('kpiName');",
               "    pm.expect(response).to.have.property('kpiDescription');",
               "    pm.expect(response).to.have.property('kpiDescriptionUrl');",
@@ -167,7 +167,7 @@
           }
         ],
         "url": {
-          "raw": "{{HOSTNAME}}/fdr-kpi/{{KPI_TYPE_NRFDR}}?brokerId={{BROKER_ID}}&period={{PERIOD_DAY}}&date={{DATE_DAY}}",
+          "raw": "{{HOSTNAME}}/fdr-kpi/{{KPI_TYPE_NRFDR}}?brokerFiscalCode={{BROKER_FISCAL_CODE}}&period={{PERIOD_DAY}}&date={{DATE_DAY}}",
           "host": ["{{HOSTNAME}}"],
           "path": [
             "fdr-kpi",
@@ -175,8 +175,8 @@
           ],
           "query": [
             {
-              "key": "brokerId",
-              "value": "{{BROKER_ID}}"
+              "key": "brokerFiscalCode",
+              "value": "{{BROKER_FISCAL_CODE}}"
             },
             {
               "key": "period",
@@ -204,7 +204,7 @@
               "    const kpiType = pm.request.url.path[1];",
               "    const expectedResponseType = `${period === 'monthly' ? 'Monthly' : 'Daily'}${kpiType}Metrics`;",
               "    pm.expect(response).to.have.property('responseType').to.equal(expectedResponseType);",
-              "    pm.expect(response).to.have.property('brokerId');",
+              "    pm.expect(response).to.have.property('brokerFiscalCode');",
               "    pm.expect(response).to.have.property('pspId');",
               "    pm.expect(response).to.have.property('kpiName');",
               "    pm.expect(response).to.have.property('kpiDescription');",
@@ -230,7 +230,7 @@
           }
         ],
         "url": {
-          "raw": "{{HOSTNAME}}/fdr-kpi/{{KPI_TYPE_WAFDR}}?brokerId={{BROKER_ID}}&pspId={{PSP_ID}}&period={{PERIOD_DAY}}&date={{DATE_DAY}}",
+          "raw": "{{HOSTNAME}}/fdr-kpi/{{KPI_TYPE_WAFDR}}?brokerFiscalCode={{BROKER_FISCAL_CODE}}&pspId={{PSP_ID}}&period={{PERIOD_DAY}}&date={{DATE_DAY}}",
           "host": ["{{HOSTNAME}}"],
           "path": [
             "fdr-kpi",
@@ -238,8 +238,8 @@
           ],
           "query": [
             {
-              "key": "brokerId",
-              "value": "{{BROKER_ID}}"
+              "key": "brokerFiscalCode",
+              "value": "{{BROKER_FISCAL_CODE}}"
             },
             {
               "key": "pspId",

--- a/api-tests/v1/qi-fdrkpi.api.tests.uat.json
+++ b/api-tests/v1/qi-fdrkpi.api.tests.uat.json
@@ -83,7 +83,7 @@
               "    const kpiType = pm.request.url.path[1];",
               "    const expectedResponseType = `${period === 'monthly' ? 'Monthly' : 'Daily'}${kpiType}Metrics`;",
               "    pm.expect(response).to.have.property('responseType').to.equal(expectedResponseType);",
-              "    pm.expect(response).to.have.property('brokerId');",
+              "    pm.expect(response).to.have.property('brokerFiscalCode');",
               "    pm.expect(response).to.have.property('kpiName');",
               "    pm.expect(response).to.have.property('kpiDescription');",
               "    pm.expect(response).to.have.property('kpiDescriptionUrl');",
@@ -108,7 +108,7 @@
           }
         ],
         "url": {
-          "raw": "{{HOSTNAME}}/qi/fdr-kpi-service/v1/fdr-kpi/{{KPI_TYPE_WPNFDR}}?brokerId={{BROKER_ID}}&period={{PERIOD_MONTH}}&date={{DATE_MONTH}}",
+          "raw": "{{HOSTNAME}}/qi/fdr-kpi-service/v1/fdr-kpi/{{KPI_TYPE_WPNFDR}}?brokerFiscalCode={{BROKER_FISCAL_CODE}}&period={{PERIOD_MONTH}}&date={{DATE_MONTH}}",
           "host": ["{{HOSTNAME}}"],
           "path": [
             "qi",
@@ -119,8 +119,8 @@
           ],
           "query": [
             {
-              "key": "brokerId",
-              "value": "{{BROKER_ID}}"
+              "key": "brokerFiscalCode",
+              "value": "{{BROKER_FISCAL_CODE}}"
             },
             {
               "key": "period",
@@ -148,7 +148,7 @@
               "    const kpiType = pm.request.url.path[1];",
               "    const expectedResponseType = `${period === 'monthly' ? 'Monthly' : 'Daily'}${kpiType}Metrics`;",
               "    pm.expect(response).to.have.property('responseType').to.equal(expectedResponseType);",
-              "    pm.expect(response).to.have.property('brokerId');",
+              "    pm.expect(response).to.have.property('brokerFiscalCode');",
               "    pm.expect(response).to.have.property('kpiName');",
               "    pm.expect(response).to.have.property('kpiDescription');",
               "    pm.expect(response).to.have.property('kpiDescriptionUrl');",
@@ -173,7 +173,7 @@
           }
         ],
         "url": {
-          "raw": "{{HOSTNAME}}/qi/fdr-kpi-service/v1/fdr-kpi/{{KPI_TYPE_NRFDR}}?brokerId={{BROKER_ID}}&period={{PERIOD_DAY}}&date={{DATE_DAY}}",
+          "raw": "{{HOSTNAME}}/qi/fdr-kpi-service/v1/fdr-kpi/{{KPI_TYPE_NRFDR}}?brokerFiscalCode={{BROKER_FISCAL_CODE}}&period={{PERIOD_DAY}}&date={{DATE_DAY}}",
           "host": ["{{HOSTNAME}}"],
           "path": [
             "qi",
@@ -184,8 +184,8 @@
           ],
           "query": [
             {
-              "key": "brokerId",
-              "value": "{{BROKER_ID}}"
+              "key": "brokerFiscalCode",
+              "value": "{{BROKER_FISCAL_CODE}}"
             },
             {
               "key": "period",
@@ -213,7 +213,7 @@
               "    const kpiType = pm.request.url.path[1];",
               "    const expectedResponseType = `${period === 'monthly' ? 'Monthly' : 'Daily'}${kpiType}Metrics`;",
               "    pm.expect(response).to.have.property('responseType').to.equal(expectedResponseType);",
-              "    pm.expect(response).to.have.property('brokerId');",
+              "    pm.expect(response).to.have.property('brokerFiscalCode');",
               "    pm.expect(response).to.have.property('pspId');",
               "    pm.expect(response).to.have.property('kpiName');",
               "    pm.expect(response).to.have.property('kpiDescription');",
@@ -239,7 +239,7 @@
           }
         ],
         "url": {
-          "raw": "{{HOSTNAME}}/qi/fdr-kpi-service/v1/fdr-kpi/{{KPI_TYPE_WAFDR}}?brokerId={{BROKER_ID}}&pspId={{PSP_ID}}&period={{PERIOD_DAY}}&date={{DATE_DAY}}",
+          "raw": "{{HOSTNAME}}/qi/fdr-kpi-service/v1/fdr-kpi/{{KPI_TYPE_WAFDR}}?brokerFiscalCode={{BROKER_FISCAL_CODE}}&pspId={{PSP_ID}}&period={{PERIOD_DAY}}&date={{DATE_DAY}}",
           "host": ["{{HOSTNAME}}"],
           "path": [
             "qi",
@@ -250,8 +250,8 @@
           ],
           "query": [
             {
-              "key": "brokerId",
-              "value": "{{BROKER_ID}}"
+              "key": "brokerFiscalCode",
+              "value": "{{BROKER_FISCAL_CODE}}"
             },
             {
               "key": "pspId",

--- a/src/main/kotlin/it/pagopa/qi/fdrkpi/controller/v1/FdrKpiController.kt
+++ b/src/main/kotlin/it/pagopa/qi/fdrkpi/controller/v1/FdrKpiController.kt
@@ -19,7 +19,7 @@ class FdrKpiController(@Autowired private val fdrKpiService: FdrKpiService) : Fd
      * @param period The time period granularity (single day or calendar month) (required)
      * @param date For daily KPIs: Specify the full date (YYYY-MM-DD). Must be at least 10 days
      *   before current date. For monthly KPIs: Specify year and month (YYYY-MM). (required)
-     * @param brokerId The fiscal code of the broker
+     * @param brokerFiscalCode The fiscal code of the broker
      * @param pspId The fiscal code of the PSP
      * @return KPI calculated (status code 200) or Formally invalid input Possible error types: -
      *   DATE_TOO_RECENT: Daily KPI requests must be for dates at least 10 days in the past (status
@@ -30,13 +30,14 @@ class FdrKpiController(@Autowired private val fdrKpiService: FdrKpiService) : Fd
         kpiType: String,
         period: String,
         date: String,
-        brokerId: String?,
+        brokerFiscalCode: String?,
         pspId: String?
     ): ResponseEntity<KPIResponseDto> {
         val requesterInfo =
             when {
-                brokerId != null && pspId != null -> "Broker [$brokerId] (for PSP [$pspId])"
-                brokerId != null -> "Broker [$brokerId]"
+                brokerFiscalCode != null && pspId != null ->
+                    "Broker [$brokerFiscalCode] (for PSP [$pspId])"
+                brokerFiscalCode != null -> "Broker [$brokerFiscalCode]"
                 pspId != null -> "PSP [$pspId]"
                 else -> "Unknown requester"
             }
@@ -50,7 +51,8 @@ class FdrKpiController(@Autowired private val fdrKpiService: FdrKpiService) : Fd
         )
 
         try {
-            val response = fdrKpiService.calculateKpi(kpiType, period, date, brokerId, pspId)
+            val response =
+                fdrKpiService.calculateKpi(kpiType, period, date, brokerFiscalCode, pspId)
             logger.info(
                 "Successfully calculated [{}] [{}] KPI for {} for date [{}]",
                 period,

--- a/src/main/kotlin/it/pagopa/qi/fdrkpi/dataprovider/kusto/v1/KustoQueries.kt
+++ b/src/main/kotlin/it/pagopa/qi/fdrkpi/dataprovider/kusto/v1/KustoQueries.kt
@@ -20,13 +20,13 @@ package it.pagopa.qi.fdrkpi.dataprovider.kusto.v1
  */
 object KustoQueries {
 
-    fun generateIdFilter(brokerId: String?, pspId: String?): String {
+    fun generateIdFilter(brokerFiscalCode: String?, pspId: String?): String {
         return when {
-            pspId != null && brokerId != null ->
-                "| where ID_PSP == \"$pspId\" and ID_BROKER_PSP == \"$brokerId\""
+            pspId != null && brokerFiscalCode != null ->
+                "| where ID_PSP == \"$pspId\" and ID_BROKER_PSP == \"$brokerFiscalCode\""
             pspId != null -> "| where ID_PSP == \"$pspId\""
-            brokerId != null -> "| where ID_BROKER_PSP == \"$brokerId\""
-            else -> throw RuntimeException("BrokerId and PspId are not defined")
+            brokerFiscalCode != null -> "| where ID_BROKER_PSP == \"$brokerFiscalCode\""
+            else -> throw RuntimeException("BrokerFiscalCode and PspId are not defined")
         }
     }
 

--- a/src/main/kotlin/it/pagopa/qi/fdrkpi/service/FdrKpiService.kt
+++ b/src/main/kotlin/it/pagopa/qi/fdrkpi/service/FdrKpiService.kt
@@ -35,7 +35,7 @@ class FdrKpiService(
         kpiType: String,
         period: String,
         date: String,
-        brokerId: String?,
+        brokerFiscalCode: String?,
         pspId: String?
     ): KPIResponseDto {
         validateInputs(kpiType, period, date)
@@ -43,19 +43,20 @@ class FdrKpiService(
         val dateRange = getDateRange(FdrKpiPeriod.valueOf(period), date)
         val totalReports =
             if (FdrKpiPeriod.daily == FdrKpiPeriod.valueOf(period)) {
-                executeQuery(KustoQueries.TOTAL_FLOWS_QUERY, dateRange, brokerId, pspId)
+                executeQuery(KustoQueries.TOTAL_FLOWS_QUERY, dateRange, brokerFiscalCode, pspId)
                     .firstOrNull() as? Int
                     ?: 0
             } else 0
 
         return when (KpiNameEnum.valueOf(kpiType)) {
-            KpiNameEnum.LFDR -> buildLfdrResponse(period, dateRange, totalReports, brokerId, pspId)
+            KpiNameEnum.LFDR ->
+                buildLfdrResponse(period, dateRange, totalReports, brokerFiscalCode, pspId)
             KpiNameEnum.WAFDR ->
-                buildWafdrResponse(period, dateRange, totalReports, brokerId, pspId)
+                buildWafdrResponse(period, dateRange, totalReports, brokerFiscalCode, pspId)
             KpiNameEnum.NRFDR ->
-                buildNrfdrResponse(period, dateRange, totalReports, brokerId, pspId)
+                buildNrfdrResponse(period, dateRange, totalReports, brokerFiscalCode, pspId)
             KpiNameEnum.WPNFDR ->
-                buildWpnfdrResponse(period, dateRange, totalReports, brokerId, pspId)
+                buildWpnfdrResponse(period, dateRange, totalReports, brokerFiscalCode, pspId)
         }
     }
 
@@ -63,11 +64,11 @@ class FdrKpiService(
         period: String,
         dateRange: Pair<LocalDate, LocalDate>,
         totalReports: Int,
-        brokerId: String?,
+        brokerFiscalCode: String?,
         pspId: String?
     ): KPIResponseDto {
-        val result = executeQuery(LFDR_QUERY, dateRange, brokerId, pspId)
-        val entityType = if (brokerId != null) EntityTypeEnum.BROKER else EntityTypeEnum.PSP
+        val result = executeQuery(LFDR_QUERY, dateRange, brokerFiscalCode, pspId)
+        val entityType = if (brokerFiscalCode != null) EntityTypeEnum.BROKER else EntityTypeEnum.PSP
 
         return when (FdrKpiPeriod.valueOf(period)) {
             FdrKpiPeriod.daily -> {
@@ -99,7 +100,7 @@ class FdrKpiService(
                     lateReportsFirst,
                     lateReportsSecond,
                     entityType,
-                    brokerId,
+                    brokerFiscalCode,
                     pspId
                 )
             }
@@ -108,7 +109,7 @@ class FdrKpiService(
                     result[0].toString(),
                     result[1].toString(),
                     entityType,
-                    brokerId,
+                    brokerFiscalCode,
                     pspId
                 )
         }
@@ -118,11 +119,11 @@ class FdrKpiService(
         period: String,
         dateRange: Pair<LocalDate, LocalDate>,
         totalReports: Int,
-        brokerId: String?,
+        brokerFiscalCode: String?,
         pspId: String?
     ): KPIResponseDto {
-        val result = executeQuery(WAFDR_QUERY, dateRange, brokerId, pspId)
-        val entityType = if (brokerId != null) EntityTypeEnum.BROKER else EntityTypeEnum.PSP
+        val result = executeQuery(WAFDR_QUERY, dateRange, brokerFiscalCode, pspId)
+        val entityType = if (brokerFiscalCode != null) EntityTypeEnum.BROKER else EntityTypeEnum.PSP
 
         return when (FdrKpiPeriod.valueOf(period)) {
             FdrKpiPeriod.daily -> {
@@ -132,12 +133,12 @@ class FdrKpiService(
                     totalReports,
                     wrongAmountReports,
                     entityType,
-                    brokerId,
+                    brokerFiscalCode,
                     pspId
                 )
             }
             FdrKpiPeriod.monthly ->
-                monthlyWafdrBuilder(result[0].toString(), entityType, brokerId, pspId)
+                monthlyWafdrBuilder(result[0].toString(), entityType, brokerFiscalCode, pspId)
         }
     }
 
@@ -145,11 +146,11 @@ class FdrKpiService(
         period: String,
         dateRange: Pair<LocalDate, LocalDate>,
         totalReports: Int,
-        brokerId: String?,
+        brokerFiscalCode: String?,
         pspId: String?
     ): KPIResponseDto {
-        val result = executeQuery(NRFDR_QUERY, dateRange, brokerId, pspId)
-        val entityType = if (brokerId != null) EntityTypeEnum.BROKER else EntityTypeEnum.PSP
+        val result = executeQuery(NRFDR_QUERY, dateRange, brokerFiscalCode, pspId)
+        val entityType = if (brokerFiscalCode != null) EntityTypeEnum.BROKER else EntityTypeEnum.PSP
 
         return when (FdrKpiPeriod.valueOf(period)) {
             FdrKpiPeriod.daily -> {
@@ -160,12 +161,12 @@ class FdrKpiService(
                     missingReports,
                     totalReports - missingReports,
                     entityType,
-                    brokerId,
+                    brokerFiscalCode,
                     pspId
                 )
             }
             FdrKpiPeriod.monthly ->
-                monthlyNrfdrBuilder(result[0].toString(), entityType, brokerId, pspId)
+                monthlyNrfdrBuilder(result[0].toString(), entityType, brokerFiscalCode, pspId)
         }
     }
 
@@ -173,11 +174,11 @@ class FdrKpiService(
         period: String,
         dateRange: Pair<LocalDate, LocalDate>,
         totalReports: Int,
-        brokerId: String?,
+        brokerFiscalCode: String?,
         pspId: String?
     ): KPIResponseDto {
-        val result = executeQuery(WPNFDR_QUERY, dateRange, brokerId, pspId)
-        val entityType = if (brokerId != null) EntityTypeEnum.BROKER else EntityTypeEnum.PSP
+        val result = executeQuery(WPNFDR_QUERY, dateRange, brokerFiscalCode, pspId)
+        val entityType = if (brokerFiscalCode != null) EntityTypeEnum.BROKER else EntityTypeEnum.PSP
 
         return when (FdrKpiPeriod.valueOf(period)) {
             FdrKpiPeriod.daily -> {
@@ -187,12 +188,12 @@ class FdrKpiService(
                     totalReports,
                     wrongPaymentNumReports,
                     entityType,
-                    brokerId,
+                    brokerFiscalCode,
                     pspId
                 )
             }
             FdrKpiPeriod.monthly ->
-                monthlyWpnfdrBuilder(result[0].toString(), entityType, brokerId, pspId)
+                monthlyWpnfdrBuilder(result[0].toString(), entityType, brokerFiscalCode, pspId)
         }
     }
 
@@ -205,10 +206,11 @@ class FdrKpiService(
     private fun executeQuery(
         query: String,
         dateRange: Pair<LocalDate, LocalDate>,
-        brokerId: String?,
+        brokerFiscalCode: String?,
         pspId: String?
     ): List<Any> {
-        val preparedQuery = prepareQuery(query, dateRange.first, dateRange.second, brokerId, pspId)
+        val preparedQuery =
+            prepareQuery(query, dateRange.first, dateRange.second, brokerFiscalCode, pspId)
         logger.debug("Executing query: $preparedQuery")
         return try {
             val result = reKustoClient.executeQuery(database, preparedQuery)

--- a/src/main/kotlin/it/pagopa/qi/fdrkpi/utils/FdrKpiResponseBuilder.kt
+++ b/src/main/kotlin/it/pagopa/qi/fdrkpi/utils/FdrKpiResponseBuilder.kt
@@ -22,18 +22,18 @@ fun dailyLfdrBuilder(
     lateFdrV1: Int,
     lateFdrV2: Int,
     entityType: EntityTypeEnum,
-    brokerId: String?,
+    brokerFiscalCode: String?,
     pspId: String?
 ): DailyLFDRMetricsDto {
     logger.debug(
-        "Building daily LFDR metrics for date [{}], total reports: [{}], late FDR v1: [{}], late FDR v2: [{}], entity type: [{}], pspId: [{}], brokerId: [{}]",
+        "Building daily LFDR metrics for date [{}], total reports: [{}], late FDR v1: [{}], late FDR v2: [{}], entity type: [{}], pspId: [{}], brokerFiscalCode: [{}]",
         paymentDate,
         totalReports,
         lateFdrV1,
         lateFdrV2,
         entityType,
         pspId,
-        brokerId
+        brokerFiscalCode
     )
     return DailyLFDRMetricsDto(
             paymentDate,
@@ -47,23 +47,23 @@ fun dailyLfdrBuilder(
             KpiNameEnum.LFDR
         )
         .pspId(pspId ?: NOT_SPECIFIED)
-        .brokerId(brokerId ?: NOT_SPECIFIED)
+        .brokerFiscalCode(brokerFiscalCode ?: NOT_SPECIFIED)
 }
 
 fun monthlyLfdrBuilder(
     kpiLfdrV1Value: String,
     kpiLfdrV2Value: String,
     entityType: EntityTypeEnum,
-    brokerId: String?,
+    brokerFiscalCode: String?,
     pspId: String?
 ): MonthlyLFDRMetricsDto {
     logger.debug(
-        "Building monthly LFDR metrics with v1 value: [{}], v2 value: [{}], entity type: [{}], pspId: [{}], brokerId: [{}]",
+        "Building monthly LFDR metrics with v1 value: [{}], v2 value: [{}], entity type: [{}], pspId: [{}], brokerFiscalCode: [{}]",
         kpiLfdrV1Value,
         kpiLfdrV2Value,
         entityType,
         pspId,
-        brokerId
+        brokerFiscalCode
     )
     return MonthlyLFDRMetricsDto(
             "monthly",
@@ -75,7 +75,7 @@ fun monthlyLfdrBuilder(
             KpiNameEnum.LFDR
         )
         .pspId(pspId ?: NOT_SPECIFIED)
-        .brokerId(brokerId ?: NOT_SPECIFIED)
+        .brokerFiscalCode(brokerFiscalCode ?: NOT_SPECIFIED)
 }
 
 // --- Nrfdr
@@ -85,18 +85,18 @@ fun dailyNrfdrBuilder(
     missingReports: Int,
     foundReports: Int,
     entityType: EntityTypeEnum,
-    brokerId: String?,
+    brokerFiscalCode: String?,
     pspId: String?
 ): DailyNRFDRMetricsDto {
     logger.debug(
-        "Building daily NRFDR metrics for date [{}], total reports: [{}], missing reports: [{}], found reports: [{}], entity type: [{}], pspId: [{}], brokerId: [{}]",
+        "Building daily NRFDR metrics for date [{}], total reports: [{}], missing reports: [{}], found reports: [{}], entity type: [{}], pspId: [{}], brokerFiscalCode: [{}]",
         paymentDate,
         totalReports,
         missingReports,
         foundReports,
         entityType,
         pspId,
-        brokerId
+        brokerFiscalCode
     )
     return DailyNRFDRMetricsDto(
             paymentDate,
@@ -110,21 +110,21 @@ fun dailyNrfdrBuilder(
             KpiNameEnum.NRFDR
         )
         .pspId(pspId ?: NOT_SPECIFIED)
-        .brokerId(brokerId ?: NOT_SPECIFIED)
+        .brokerFiscalCode(brokerFiscalCode ?: NOT_SPECIFIED)
 }
 
 fun monthlyNrfdrBuilder(
     kpiValue: String,
     entityType: EntityTypeEnum,
-    brokerId: String?,
+    brokerFiscalCode: String?,
     pspId: String?
 ): MonthlyNRFDRMetricsDto {
     logger.debug(
-        "Building monthly NRFDR metrics with value: [{}], entity type: [{}], pspId: [{}], brokerId: [{}]",
+        "Building monthly NRFDR metrics with value: [{}], entity type: [{}], pspId: [{}], brokerFiscalCode: [{}]",
         kpiValue,
         entityType,
         pspId,
-        brokerId
+        brokerFiscalCode
     )
     return MonthlyNRFDRMetricsDto(
             kpiValue,
@@ -135,7 +135,7 @@ fun monthlyNrfdrBuilder(
             KpiNameEnum.NRFDR
         )
         .pspId(pspId ?: NOT_SPECIFIED)
-        .brokerId(brokerId ?: NOT_SPECIFIED)
+        .brokerFiscalCode(brokerFiscalCode ?: NOT_SPECIFIED)
 }
 
 // --- Wpnfdr
@@ -144,17 +144,17 @@ fun dailyWpnfdrBuilder(
     totalReports: Int,
     totalDiffNum: Int,
     entityType: EntityTypeEnum,
-    brokerId: String?,
+    brokerFiscalCode: String?,
     pspId: String?
 ): DailyWPNFDRMetricsDto {
     logger.debug(
-        "Building daily WPNFDR metrics for date [{}], total reports: [{}], total diff num: [{}], entity type: [{}], pspId: [{}], brokerId: [{}]",
+        "Building daily WPNFDR metrics for date [{}], total reports: [{}], total diff num: [{}], entity type: [{}], pspId: [{}], brokerFiscalCode: [{}]",
         paymentDate,
         totalReports,
         totalDiffNum,
         entityType,
         pspId,
-        brokerId
+        brokerFiscalCode
     )
     return DailyWPNFDRMetricsDto(
             paymentDate,
@@ -167,21 +167,21 @@ fun dailyWpnfdrBuilder(
             KpiNameEnum.WPNFDR
         )
         .pspId(pspId ?: NOT_SPECIFIED)
-        .brokerId(brokerId ?: NOT_SPECIFIED)
+        .brokerFiscalCode(brokerFiscalCode ?: NOT_SPECIFIED)
 }
 
 fun monthlyWpnfdrBuilder(
     kpiValue: String,
     entityType: EntityTypeEnum,
-    brokerId: String?,
+    brokerFiscalCode: String?,
     pspId: String?
 ): MonthlyWPNFDRMetricsDto {
     logger.debug(
-        "Building monthly WPNFDR metrics with value: [{}], entity type: [{}], pspId: [{}], brokerId: [{}]",
+        "Building monthly WPNFDR metrics with value: [{}], entity type: [{}], pspId: [{}], brokerFiscalCode: [{}]",
         kpiValue,
         entityType,
         pspId,
-        brokerId
+        brokerFiscalCode
     )
     return MonthlyWPNFDRMetricsDto(
             kpiValue,
@@ -192,7 +192,7 @@ fun monthlyWpnfdrBuilder(
             KpiNameEnum.WPNFDR
         )
         .pspId(pspId ?: NOT_SPECIFIED)
-        .brokerId(brokerId ?: NOT_SPECIFIED)
+        .brokerFiscalCode(brokerFiscalCode ?: NOT_SPECIFIED)
 }
 
 // --- Wafdr
@@ -201,17 +201,17 @@ fun dailyWafdrBuilder(
     totalReports: Int,
     totalDiffNum: Int,
     entityType: EntityTypeEnum,
-    brokerId: String?,
+    brokerFiscalCode: String?,
     pspId: String?
 ): DailyWAFDRMetricsDto {
     logger.debug(
-        "Building daily WAFDR metrics for date [{}], total reports: [{}], total diff num: [{}], entity type: [{}], pspId: [{}], brokerId: [{}]",
+        "Building daily WAFDR metrics for date [{}], total reports: [{}], total diff num: [{}], entity type: [{}], pspId: [{}], brokerFiscalCode: [{}]",
         paymentDate,
         totalReports,
         totalDiffNum,
         entityType,
         pspId,
-        brokerId
+        brokerFiscalCode
     )
     return DailyWAFDRMetricsDto(
             paymentDate,
@@ -224,21 +224,21 @@ fun dailyWafdrBuilder(
             KpiNameEnum.WAFDR
         )
         .pspId(pspId ?: NOT_SPECIFIED)
-        .brokerId(brokerId ?: NOT_SPECIFIED)
+        .brokerFiscalCode(brokerFiscalCode ?: NOT_SPECIFIED)
 }
 
 fun monthlyWafdrBuilder(
     kpiValue: String,
     entityType: EntityTypeEnum,
-    brokerId: String?,
+    brokerFiscalCode: String?,
     pspId: String?
 ): MonthlyWPNFDRMetricsDto {
     logger.debug(
-        "Building monthly WAFDR metrics with value: [{}], entity type: [{}], pspId: [{}], brokerId: [{}]",
+        "Building monthly WAFDR metrics with value: [{}], entity type: [{}], pspId: [{}], brokerFiscalCode: [{}]",
         kpiValue,
         entityType,
         pspId,
-        brokerId
+        brokerFiscalCode
     )
     return MonthlyWPNFDRMetricsDto(
             kpiValue,
@@ -249,5 +249,5 @@ fun monthlyWafdrBuilder(
             KpiNameEnum.WAFDR
         )
         .pspId(pspId ?: NOT_SPECIFIED)
-        .brokerId(brokerId ?: NOT_SPECIFIED)
+        .brokerFiscalCode(brokerFiscalCode ?: NOT_SPECIFIED)
 }

--- a/src/main/kotlin/it/pagopa/qi/fdrkpi/utils/QueryUtils.kt
+++ b/src/main/kotlin/it/pagopa/qi/fdrkpi/utils/QueryUtils.kt
@@ -14,13 +14,13 @@ fun prepareQuery(
     query: String,
     startDate: LocalDate,
     endDate: LocalDate,
-    brokerId: String? = null,
+    brokerFiscalCode: String? = null,
     pspId: String? = null
 ): String {
     return query
         .replace("\$START_DATE", startDate.toString())
         .replace("\$END_DATE", endDate.toString())
-        .replace("\$FILTER", generateIdFilter(brokerId, pspId))
+        .replace("\$FILTER", generateIdFilter(brokerFiscalCode, pspId))
 }
 
 fun getDateRange(period: FdrKpiPeriod, date: String): Pair<LocalDate, LocalDate> {

--- a/src/test/kotlin/it/pagopa/qi/fdrkpi/controller/v1/FdrKpiControllerTest.kt
+++ b/src/test/kotlin/it/pagopa/qi/fdrkpi/controller/v1/FdrKpiControllerTest.kt
@@ -45,8 +45,8 @@ class FdrKpiControllerTest {
 
     @ParameterizedTest
     @MethodSource("requesterInfoProvider")
-    fun `Should correctly format requester info for different combinations of brokerId and pspId`(
-        brokerId: String?,
+    fun `Should correctly format requester info for different combinations of brokerFiscalCode and pspId`(
+        brokerFiscalCode: String?,
         pspId: String?
     ) {
         val kpiResponse =
@@ -56,14 +56,15 @@ class FdrKpiControllerTest {
                 lateFdrV1 = 1,
                 lateFdrV2 = 2,
                 entityType = EntityTypeEnum.PSP,
-                brokerId = brokerId,
+                brokerFiscalCode = brokerFiscalCode,
                 pspId = pspId
             )
 
-        given(fdrKpiService.calculateKpi("LFDR", "daily", "2023-10-01", brokerId, pspId))
+        given(fdrKpiService.calculateKpi("LFDR", "daily", "2023-10-01", brokerFiscalCode, pspId))
             .willReturn(kpiResponse)
 
-        val response = fdrKpiController.calculateKpi("LFDR", "daily", "2023-10-01", brokerId, pspId)
+        val response =
+            fdrKpiController.calculateKpi("LFDR", "daily", "2023-10-01", brokerFiscalCode, pspId)
 
         assertEquals(ResponseEntity.ok(kpiResponse), response)
     }

--- a/src/test/kotlin/it/pagopa/qi/fdrkpi/service/FdrKpiServiceTest.kt
+++ b/src/test/kotlin/it/pagopa/qi/fdrkpi/service/FdrKpiServiceTest.kt
@@ -81,7 +81,7 @@ class FdrKpiServiceTest {
                         lateFdrV1 = 2,
                         lateFdrV2 = 3,
                         entityType = EntityTypeEnum.PSP,
-                        brokerId = null,
+                        brokerFiscalCode = null,
                         pspId = pspID
                     )
                 ),
@@ -97,7 +97,7 @@ class FdrKpiServiceTest {
                         totalReports = 10,
                         totalDiffNum = 3,
                         entityType = EntityTypeEnum.PSP,
-                        brokerId = null,
+                        brokerFiscalCode = null,
                         pspId = pspID
                     )
                 ),
@@ -123,7 +123,7 @@ class FdrKpiServiceTest {
                         missingReports = 2,
                         foundReports = 8,
                         entityType = EntityTypeEnum.PSP,
-                        brokerId = null,
+                        brokerFiscalCode = null,
                         pspId = pspID
                     )
                 ),
@@ -148,7 +148,7 @@ class FdrKpiServiceTest {
                         totalReports = 10,
                         totalDiffNum = 4,
                         entityType = EntityTypeEnum.PSP,
-                        brokerId = null,
+                        brokerFiscalCode = null,
                         pspId = pspID
                     )
                 ),
@@ -178,16 +178,28 @@ class FdrKpiServiceTest {
         val dateString = if (fdrKpiPeriod == FdrKpiPeriod.daily) "2023-10-01" else "2023-10"
         val dateRange = getDateRange(fdrKpiPeriod, dateString)
         val pspId = "SARDIT31"
-        val brokerId: String? = null
+        val brokerFiscalCode: String? = null
 
         if (fdrKpiPeriod == FdrKpiPeriod.daily) {
-            mockKustoResponse(TOTAL_FLOWS_QUERY, dateRange, pspId, brokerId, listOf(totalReports))
+            mockKustoResponse(
+                TOTAL_FLOWS_QUERY,
+                dateRange,
+                pspId,
+                brokerFiscalCode,
+                listOf(totalReports)
+            )
         }
 
-        mockKustoResponse(queryString, dateRange, pspId, brokerId, queryResponse)
+        mockKustoResponse(queryString, dateRange, pspId, brokerFiscalCode, queryResponse)
 
         val response =
-            fdrKpiService.calculateKpi(kpiType.name, fdrKpiPeriod.name, dateString, brokerId, pspId)
+            fdrKpiService.calculateKpi(
+                kpiType.name,
+                fdrKpiPeriod.name,
+                dateString,
+                brokerFiscalCode,
+                pspId
+            )
 
         assertEquals(expectedResponse, response)
     }
@@ -327,24 +339,24 @@ class FdrKpiServiceTest {
     }
 
     @Test
-    fun `Should throw RuntimeException for brokerId and pspId null on prepareQuery`() {
+    fun `Should throw RuntimeException for brokerFiscalCode and pspId null on prepareQuery`() {
         val dateRange = Pair(LocalDate.parse("2023-01-01"), LocalDate.parse("2023-01-01"))
         val ex =
             assertThrows<RuntimeException> {
                 prepareQuery(LFDR_QUERY, dateRange.first, dateRange.second)
             }
-        assertEquals("BrokerId and PspId are not defined", ex.message)
+        assertEquals("BrokerFiscalCode and PspId are not defined", ex.message)
     }
 
     private fun mockKustoResponse(
         queryString: String,
         dateRange: Pair<LocalDate, LocalDate>,
         pspId: String?,
-        brokerId: String?,
+        brokerFiscalCode: String?,
         responseRow: List<Any>
     ) {
         val preparedQuery =
-            prepareQuery(queryString, dateRange.first, dateRange.second, brokerId, pspId)
+            prepareQuery(queryString, dateRange.first, dateRange.second, brokerFiscalCode, pspId)
         val operationResult = mock(KustoOperationResult::class.java)
         val resultSet = mock(KustoResultSetTable::class.java)
 

--- a/src/test/kotlin/it/pagopa/qi/fdrkpi/utils/QueryUtilsTest.kt
+++ b/src/test/kotlin/it/pagopa/qi/fdrkpi/utils/QueryUtilsTest.kt
@@ -17,9 +17,9 @@ class QueryUtilsTest {
         val startDate = LocalDate.of(2024, 1, 1)
         val endDate = LocalDate.of(2024, 1, 31)
         val pspId = "PSP123"
-        val brokerId = "01234556789"
+        val brokerFiscalCode = "01234556789"
 
-        val result = prepareQuery(query, startDate, endDate, brokerId, pspId)
+        val result = prepareQuery(query, startDate, endDate, brokerFiscalCode, pspId)
 
         val expected =
             "SELECT * FROM table | where ID_PSP == \"PSP123\" and ID_BROKER_PSP == \"01234556789\" | where GIORNATA_PAGAMENTO between (datetime(2024-01-01) .. datetime(2024-01-31))"

--- a/src/test/kotlin/it/pagopa/qi/fdrkpi/utils/ResponseBuilderTest.kt
+++ b/src/test/kotlin/it/pagopa/qi/fdrkpi/utils/ResponseBuilderTest.kt
@@ -14,12 +14,13 @@ class ResponseBuilderTest {
         URI(
             "https://developer.pagopa.it/pago-pa/guides/sanp/prestatore-di-servizi-di-pagamento/quality-improvement"
         )
-    private val brokerId = "01153230360"
+    private val brokerFiscalCode = "01153230360"
     private val pspId = "SARDIT31"
 
     @Test
     fun `Should return DailyLFDRMetricsDto`() {
-        val result = dailyLfdrBuilder(paymentDate, 1, 1, 1, EntityTypeEnum.PSP, brokerId, pspId)
+        val result =
+            dailyLfdrBuilder(paymentDate, 1, 1, 1, EntityTypeEnum.PSP, brokerFiscalCode, pspId)
         assertEquals(paymentDate, result.paymentDate)
         assertEquals(1, result.totalReports)
         assertEquals(1, result.lateFdrV1)
@@ -32,7 +33,7 @@ class ResponseBuilderTest {
     }
     @Test
     fun `Should return MonthlyLFDRMetricsDto`() {
-        val result = monthlyLfdrBuilder("90%", "80%", EntityTypeEnum.PSP, brokerId, pspId)
+        val result = monthlyLfdrBuilder("90%", "80%", EntityTypeEnum.PSP, brokerFiscalCode, pspId)
         assertEquals("monthly", result.responseType)
         assertEquals("90%", result.kpiLfdrV1Value)
         assertEquals("80%", result.kpiLfdrV2Value)
@@ -44,7 +45,8 @@ class ResponseBuilderTest {
 
     @Test
     fun `Should return DailyNRFDRMetricsDto`() {
-        val result = dailyNrfdrBuilder(paymentDate, 10, 3, 7, EntityTypeEnum.PSP, brokerId, pspId)
+        val result =
+            dailyNrfdrBuilder(paymentDate, 10, 3, 7, EntityTypeEnum.PSP, brokerFiscalCode, pspId)
         assertEquals(paymentDate, result.paymentDate)
         assertEquals(10, result.totalReports)
         assertEquals("daily", result.responseType)
@@ -58,7 +60,7 @@ class ResponseBuilderTest {
 
     @Test
     fun `Should return MonthlyNRFDRMetricsDto`() {
-        val result = monthlyNrfdrBuilder("85%", EntityTypeEnum.PSP, brokerId, pspId)
+        val result = monthlyNrfdrBuilder("85%", EntityTypeEnum.PSP, brokerFiscalCode, pspId)
         assertEquals("85%", result.kpiValue)
         assertEquals("monthly", result.responseType)
         assertEquals("FdR non rendicontati", result.kpiDescription)
@@ -69,7 +71,8 @@ class ResponseBuilderTest {
 
     @Test
     fun `Should return DailyWPNFDRMetricsDto`() {
-        val result = dailyWpnfdrBuilder(paymentDate, 15, 2, EntityTypeEnum.PSP, brokerId, pspId)
+        val result =
+            dailyWpnfdrBuilder(paymentDate, 15, 2, EntityTypeEnum.PSP, brokerFiscalCode, pspId)
         assertEquals(paymentDate, result.paymentDate)
         assertEquals(15, result.totalReports)
         assertEquals("daily", result.responseType)
@@ -82,7 +85,7 @@ class ResponseBuilderTest {
 
     @Test
     fun `Should return MonthlyWPNFDRMetricsDto`() {
-        val result = monthlyWpnfdrBuilder("70%", EntityTypeEnum.PSP, brokerId, pspId)
+        val result = monthlyWpnfdrBuilder("70%", EntityTypeEnum.PSP, brokerFiscalCode, pspId)
         assertEquals("70%", result.kpiValue)
         assertEquals("monthly", result.responseType)
         assertEquals("FdR con numero di pagamenti errato", result.kpiDescription)
@@ -93,7 +96,8 @@ class ResponseBuilderTest {
 
     @Test
     fun `Should return DailyWAFDRMetricsDto`() {
-        val result = dailyWafdrBuilder(paymentDate, 20, 5, EntityTypeEnum.PSP, brokerId, pspId)
+        val result =
+            dailyWafdrBuilder(paymentDate, 20, 5, EntityTypeEnum.PSP, brokerFiscalCode, pspId)
         assertEquals(paymentDate, result.paymentDate)
         assertEquals(20, result.totalReports)
         assertEquals("daily", result.responseType)
@@ -106,7 +110,7 @@ class ResponseBuilderTest {
 
     @Test
     fun `Should return MonthlyWAFDRMetricsDto`() {
-        val result = monthlyWafdrBuilder("65%", EntityTypeEnum.PSP, brokerId, pspId)
+        val result = monthlyWafdrBuilder("65%", EntityTypeEnum.PSP, brokerFiscalCode, pspId)
         assertEquals("65%", result.kpiValue)
         assertEquals("monthly", result.responseType)
         assertEquals("FdR con importo errato", result.kpiDescription)


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- Reverted every brokerId reference back to brokerFiscalCode on openapi, kotlin, postman collections.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This revert operation aims to solve API errors when calling the service through the APIM. Since the APIM on the infrastructure and the documentation still had reference to the old "brokerFiscalCode" name, this revert solution was chosen in order to have minimal impact on the domains external to the repository.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Tested with local Postman API calls

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
